### PR TITLE
BROOKLYN-282: don’t log passwords

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/effector/MethodEffector.java
+++ b/core/src/main/java/org/apache/brooklyn/core/effector/MethodEffector.java
@@ -144,9 +144,8 @@ public class MethodEffector<T> extends AbstractEffector<T> {
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
     public T call(Entity entity, Map parameters) {
-        Object[] parametersArray = EffectorUtils.prepareArgsForEffector(this, parameters);
         if (entity instanceof AbstractEntity) {
-            return EffectorUtils.invokeMethodEffector(entity, this, parametersArray);
+            return EffectorUtils.invokeMethodEffector(entity, this, (Map<String,?>)parameters);
         } else {
             // we are dealing with a proxy here
             // this implementation invokes the method on the proxy
@@ -158,6 +157,7 @@ public class MethodEffector<T> extends AbstractEffector<T> {
             
             // TODO Should really find method with right signature, rather than just the right args.
             // TODO prepareArgs can miss things out that have "default values"! Code below will probably fail if that happens.
+            Object[] parametersArray = EffectorUtils.prepareArgsForEffector(this, parameters);
             Method[] methods = entity.getClass().getMethods();
             for (Method method : methods) {
                 if (method.getName().equals(getName())) {

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/AbstractManagementContext.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/AbstractManagementContext.java
@@ -302,7 +302,7 @@ public abstract class AbstractManagementContext implements ManagementContextInte
         return runAtEntity(entity, eff, parameters);
     }
     
-    protected <T> T invokeEffectorMethodLocal(Entity entity, Effector<T> eff, Object args) {
+    protected <T> T invokeEffectorMethodLocal(Entity entity, Effector<T> eff, Map<String, ?> args) {
         assert isManagedLocally(entity) : "cannot invoke effector method at "+this+" because it is not managed here";
         totalEffectorInvocationCount.incrementAndGet();
         Object[] transformedArgs = EffectorUtils.prepareArgsForEffector(eff, args);
@@ -315,7 +315,7 @@ public abstract class AbstractManagementContext implements ManagementContextInte
      * @throws ExecutionException 
      */
     @Override
-    public <T> T invokeEffectorMethodSync(final Entity entity, final Effector<T> eff, final Object args) throws ExecutionException {
+    public <T> T invokeEffectorMethodSync(final Entity entity, final Effector<T> eff, final Map<String, ?> args) throws ExecutionException {
         try {
             Task<?> current = Tasks.current();
             if (current == null || !entity.equals(BrooklynTaskTags.getContextEntity(current)) || !isManagedLocally(entity)) {

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/ManagementContextInternal.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/ManagementContextInternal.java
@@ -69,7 +69,7 @@ public interface ManagementContextInternal extends ManagementContext {
     
     long getTotalEffectorInvocations();
 
-    <T> T invokeEffectorMethodSync(final Entity entity, final Effector<T> eff, final Object args) throws ExecutionException;
+    <T> T invokeEffectorMethodSync(final Entity entity, final Effector<T> eff, final Map<String,?> args) throws ExecutionException;
     
     <T> Task<T> invokeEffector(final Entity entity, final Effector<T> eff, @SuppressWarnings("rawtypes") final Map parameters);
 

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/NonDeploymentManagementContext.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/NonDeploymentManagementContext.java
@@ -349,7 +349,7 @@ public class NonDeploymentManagementContext implements ManagementContextInternal
     }
     
     @Override
-    public <T> T invokeEffectorMethodSync(final Entity entity, final Effector<T> eff, final Object args) throws ExecutionException {
+    public <T> T invokeEffectorMethodSync(final Entity entity, final Effector<T> eff, final Map<String,?> args) throws ExecutionException {
         throw new IllegalStateException("Non-deployment context "+this+" is not valid for this operation: cannot invoke effector "+eff+" on entity "+entity);
     }
     

--- a/core/src/test/java/org/apache/brooklyn/core/mgmt/internal/TestEntityWithEffectors.java
+++ b/core/src/test/java/org/apache/brooklyn/core/mgmt/internal/TestEntityWithEffectors.java
@@ -21,15 +21,77 @@ package org.apache.brooklyn.core.mgmt.internal;
 import org.apache.brooklyn.api.entity.ImplementedBy;
 import org.apache.brooklyn.core.annotation.Effector;
 import org.apache.brooklyn.core.annotation.EffectorParam;
+import org.apache.brooklyn.core.effector.MethodEffector;
 import org.apache.brooklyn.core.test.entity.TestEntity;
 
+/**
+ * Entity for testing that secret effector parameters are:
+ * <ul>
+ *   <li>excluded from the activities view
+ *   <li>not logged
+ *   <li>masked out in the UI
+ * </ul>
+ * Of those, only the first is unit-tested.
+ * 
+ * To test manually...
+ * 
+ * Configure logback to log everything at trace:
+ * <pre>
+ * {@code
+ * <configuration>
+ *     <include resource="logback-main.xml"/>
+ *     <logger name="org.apache.brooklyn" level="TRACE"/>
+ *     <logger name="brooklyn" level="TRACE"/>
+ * </configuration>
+ * }
+ * </pre>
+ * 
+ * Run Brooklyn with the above log configuration file:
+ * <pre>
+ * {@code
+ * export JAVA_OPTS="-Xms256m -Xmx1g -XX:MaxPermSize=256m -Dlogback.configurationFile=/path/to/logback-trace.xml"
+ * ./bin/brooklyn launch --persist auto --persistenceDir /path/to/persistedState
+ * }
+ * </pre>
+ * 
+ * Deploy the blueprint below:
+ * <pre>
+ * {@code
+ * services:
+ * - type: org.apache.brooklyn.core.mgmt.internal.TestEntityWithEffectors
+ *   brooklyn.children:
+ *   - type: org.apache.brooklyn.core.mgmt.internal.TestEntityWithEffectors
+ * }
+ * </pre>
+ * 
+ * Invoke the effector (e.g. {@code resetPasswordOnChildren("mypassword", 12345678)} on the 
+ * top-level {@code TestEntityWithEffectors}, and the effector 
+ * {@code resetPasswordThrowsException("mypassword", 12345678)}).
+ * 
+ * Then manually check:
+ * <ul>
+ *   <li>the parameter values were masked out while being entered
+ *   <li>activity view of each TestEntityWithEffectors, that it does not show those parameter values
+ *   <li>{@code grep -E "mypassword|12345678" *.log}
+ *   <li>{@code pushd /path/to/persistedState && grep -r -E "mypassword|12345678" *}
+ * </ul>
+ */
 @ImplementedBy(TestEntityWithEffectorsImpl.class)
 public interface TestEntityWithEffectors extends TestEntity {
+    
+    org.apache.brooklyn.api.effector.Effector<Void> RESET_PASSWORD = new MethodEffector<Void>(TestEntityWithEffectors.class, "resetPassword");
+    
     @Effector(description = "Reset password")
-    Void resetPassword(@EffectorParam(name = "newPassword") String param1, @EffectorParam(name = "secretPin") Integer secretPin);
+    void resetPassword(@EffectorParam(name = "newPassword") String newPassword, @EffectorParam(name = "secretPin") Integer secretPin);
+
+    @Effector(description = "Reset password throws exception")
+    void resetPasswordThrowsException(@EffectorParam(name = "newPassword") String newPassword, @EffectorParam(name = "secretPin") Integer secretPin);
 
     @Effector(description = "Reset User and password effector")
-    Void invokeUserAndPassword(@EffectorParam(name = "user") String user,
+    void invokeUserAndPassword(@EffectorParam(name = "user") String user,
                                @EffectorParam(name = "newPassword", defaultValue = "Test") String newPassword,
                                @EffectorParam(name = "paramDefault", defaultValue = "DefaultValue") String paramDefault);
+    
+    @Effector(description = "Reset password on children")
+    void resetPasswordOnChildren(@EffectorParam(name = "newPassword") String newPassword, @EffectorParam(name = "secretPin") Integer secretPin) throws Exception;
 }

--- a/core/src/test/java/org/apache/brooklyn/core/mgmt/internal/TestEntityWithEffectorsImpl.java
+++ b/core/src/test/java/org/apache/brooklyn/core/mgmt/internal/TestEntityWithEffectorsImpl.java
@@ -18,25 +18,41 @@
  */
 package org.apache.brooklyn.core.mgmt.internal;
 
+import org.apache.brooklyn.core.entity.Entities;
 import org.apache.brooklyn.core.test.entity.TestEntityImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
 
 public class TestEntityWithEffectorsImpl extends TestEntityImpl implements TestEntityWithEffectors {
     private static final Logger log = LoggerFactory.getLogger(TestEntityWithEffectorsImpl.class);
 
     @Override
-    public Void resetPassword(String newPassword, Integer secretPin) {
+    public void resetPassword(String newPassword, Integer secretPin) {
         log.info("Invoked effector from resetPassword with params {} {}", new Object[] {newPassword, secretPin});
         assert newPassword != null;
-        return null;
     }
 
     @Override
-    public Void invokeUserAndPassword(String user,String newPassword, String paramDefault) {
+    public void resetPasswordThrowsException(String newPassword, Integer secretPin) {
+        log.info("Invoked effector from resetPasswordThrowsException with params {} {}", new Object[] {newPassword, secretPin});
+        throw new RuntimeException("Simulate failure in resetPasswordThrowsException");
+    }
+    
+    @Override
+    public void invokeUserAndPassword(String user,String newPassword, String paramDefault) {
         log.info("Invoked effector from invokeUserAndPassword with params {} {} {}", new Object[] {user, newPassword, paramDefault});
         assert user != null;
         assert newPassword != null;
-        return null;
+    }
+
+    @Override
+    public void resetPasswordOnChildren(String newPassword, Integer secretPin) throws Exception {
+        for (TestEntityWithEffectors child : Iterables.filter(getChildren(), TestEntityWithEffectors.class)) {
+            Entities.invokeEffector(this, child, RESET_PASSWORD, ImmutableMap.of("newPassword", newPassword, "secretPin", secretPin)).get();
+            child.resetPassword(newPassword, secretPin);
+        }
     }
 }


### PR DESCRIPTION
Also refactors EffectorUtils.prepareArgsForEffector (deprecating old
method), and updates how MethodEffector calls it so we have the 
parameter names.

The previous calls to `sanitizeArgs(args)` where args was not of type `Map` would do nothing. Therefore if this was ever called with an array etc, we'd log all of the parameter values.
